### PR TITLE
Release v0.2.0 #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
 
+## [v0.2.0](https://github.com/vultr/cert-manager-webhook-vultr) (2021-12-16)
+* Bumped Kubernetes to to 1.22.4, Cert-manager to 1.6.1, Go to 1.17 [PR 6](https://github.com/vultr/cert-manager-webhook-vultr/pull/6) 
+* Bump github.com/vultr/govultr/v2 from 2.4.0 to 2.12.0 [PR 3](https://github.com/vultr/cert-manager-webhook-vultr/pull/3) 
+
 ## [v0.1.0](https://github.com/vultr/cert-manager-webhook-vultr) (2021-04-20)
 Initial Release

--- a/deploy/cert-manager-webhook-vultr/Chart.yaml
+++ b/deploy/cert-manager-webhook-vultr/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 description: A Helm chart for Kubernetes
 name: cert-manager-webhook-vultr
-version: 0.1.0
+version: 0.2.0

--- a/deploy/cert-manager-webhook-vultr/values.yaml
+++ b/deploy/cert-manager-webhook-vultr/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: vultr/cert-manager-webhook-vultr
-  tag: v0.1.0
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 // GroupName ...
 var GroupName = os.Getenv("GROUP_NAME")
 
-const version = "v0.1.0"
+const version = "v0.2.0"
 
 func main() {
 	if GroupName == "" {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jetstack/cert-manager/test/acme/dns"
 )
@@ -16,6 +17,8 @@ func TestRunsSuite(t *testing.T) {
 		dns.SetResolvedZone(zone),
 		dns.SetAllowAmbientCredentials(false),
 		dns.SetManifestPath("testdata/vultr"),
+		dns.SetDNSName(zone),
+		dns.SetPropagationLimit(time.Minute*20),
 	)
 	fixture.RunConformance(t)
 }


### PR DESCRIPTION
## Description
* Bumped Kubernetes to to 1.22.4, Cert-manager to 1.6.1, Go to 1.17 [PR 6](https://github.com/vultr/cert-manager-webhook-vultr/pull/6) 
* Bump github.com/vultr/govultr/v2 from 2.4.0 to 2.12.0 [PR 3](https://github.com/vultr/cert-manager-webhook-vultr/pull/3) 

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
