### PR TITLE
Release v0.2.0 #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 * Bumped Kubernetes to to 1.22.4, Cert-manager to 1.6.1, Go to 1.17 [PR 6](https://github.com/vultr/cert-manager-webhook-vultr/pull/6) 
 * Bump github.com/vultr/govultr/v2 from 2.4.0 to 2.12.0 [PR 3](https://github.com/vultr/cert-manager-webhook-vultr/pull/3) 
 
+
 ## [v0.1.0](https://github.com/vultr/cert-manager-webhook-vultr) (2021-04-20)
 Initial Release


### PR DESCRIPTION
## Description
* Bumped Kubernetes to to 1.22.4, Cert-manager to 1.6.1, Go to 1.17 [PR 6](https://github.com/vultr/cert-manager-webhook-vultr/pull/6) 
* Bump github.com/vultr/govultr/v2 from 2.4.0 to 2.12.0 [PR 3](https://github.com/vultr/cert-manager-webhook-vultr/pull/3) 

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
