### PR TITLE
Release v0.3.0 #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v0.3.0](https://github.com/vultr/cert-manager-webhook-vultr) (2022-02-14)
+* Bump github.com/jetstack/cert-manager from 1.6.1 to 1.7.1 [PR 29](https://github.com/vultr/cert-manager-webhook-vultr/pull/29) 
+* Bump github.com/vultr/govultr/v2 from 2.12.0 to 2.14.1 [PR 28](https://github.com/vultr/cert-manager-webhook-vultr/pull/28) 
+
+
 ## [v0.2.0](https://github.com/vultr/cert-manager-webhook-vultr) (2021-12-16)
 * Bumped Kubernetes to to 1.22.4, Cert-manager to 1.6.1, Go to 1.17 [PR 6](https://github.com/vultr/cert-manager-webhook-vultr/pull/6) 
 * Bump github.com/vultr/govultr/v2 from 2.4.0 to 2.12.0 [PR 3](https://github.com/vultr/cert-manager-webhook-vultr/pull/3) 

--- a/deploy/cert-manager-webhook-vultr/Chart.yaml
+++ b/deploy/cert-manager-webhook-vultr/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.2.0"
+appVersion: "0.3.0"
 description: A Helm chart for Kubernetes
 name: cert-manager-webhook-vultr
-version: 0.2.0
+version: 0.3.0

--- a/deploy/cert-manager-webhook-vultr/values.yaml
+++ b/deploy/cert-manager-webhook-vultr/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: vultr/cert-manager-webhook-vultr
-  tag: v0.2.0
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 // GroupName ...
 var GroupName = os.Getenv("GROUP_NAME")
 
-const version = "v0.2.0"
+const version = "v0.3.0"
 
 func main() {
 	if GroupName == "" {


### PR DESCRIPTION
## [v0.3.0](https://github.com/vultr/cert-manager-webhook-vultr) (2022-02-14)
* Bump github.com/jetstack/cert-manager from 1.6.1 to 1.7.1 [PR 29](https://github.com/vultr/cert-manager-webhook-vultr/pull/29) 
* Bump github.com/vultr/govultr/v2 from 2.12.0 to 2.14.1 [PR 28](https://github.com/vultr/cert-manager-webhook-vultr/pull/28) 
