### PR TITLE
Release v0.3.1 #patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change Log
+## [v0.3.1](https://github.com/vultr/cert-manager-webhook-vultr) (2022-03-25)
+* Bump k8s.io/client-go from 0.23.1 to 0.23.5  [PR 34](https://github.com/vultr/cert-manager-webhook-vultr/pull/34) 
+* Bump k8s.io/apiextensions-apiserver from 0.23.1 to 0.23.5 [PR 36](https://github.com/vultr/cert-manager-webhook-vultr/pull/36) 
+* Bump github.com/vultr/govultr/v2 from 2.14.1 to 2.14.2 [PR 37](https://github.com/vultr/cert-manager-webhook-vultr/pull/37) 
+* Bump github.com/jetstack/cert-manager from 1.7.1 to 1.7.2 [PR 38](https://github.com/vultr/cert-manager-webhook-vultr/pull/38) 
 
 ## [v0.3.0](https://github.com/vultr/cert-manager-webhook-vultr) (2022-02-14)
 * Bump github.com/jetstack/cert-manager from 1.6.1 to 1.7.1 [PR 29](https://github.com/vultr/cert-manager-webhook-vultr/pull/29) 

--- a/deploy/cert-manager-webhook-vultr/Chart.yaml
+++ b/deploy/cert-manager-webhook-vultr/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 description: A Helm chart for Kubernetes
 name: cert-manager-webhook-vultr
-version: 0.3.0
+version: 0.3.1

--- a/deploy/cert-manager-webhook-vultr/values.yaml
+++ b/deploy/cert-manager-webhook-vultr/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: vultr/cert-manager-webhook-vultr
-  tag: v0.3.0
+  tag: v0.3.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 // GroupName ...
 var GroupName = os.Getenv("GROUP_NAME")
 
-const version = "v0.3.0"
+const version = "v0.3.1"
 
 func main() {
 	if GroupName == "" {


### PR DESCRIPTION
## [v0.3.1](https://github.com/vultr/cert-manager-webhook-vultr) (2022-03-25)
* Bump k8s.io/client-go from 0.23.1 to 0.23.5  [PR 34](https://github.com/vultr/cert-manager-webhook-vultr/pull/34) 
* Bump k8s.io/apiextensions-apiserver from 0.23.1 to 0.23.5 [PR 36](https://github.com/vultr/cert-manager-webhook-vultr/pull/36) 
* Bump github.com/vultr/govultr/v2 from 2.14.1 to 2.14.2 [PR 37](https://github.com/vultr/cert-manager-webhook-vultr/pull/37) 
* Bump github.com/jetstack/cert-manager from 1.7.1 to 1.7.2 [PR 38](https://github.com/vultr/cert-manager-webhook-vultr/pull/38) 
