### PR TITLE
added rbac secret-reader to helm

### DIFF
--- a/deploy/cert-manager-webhook-vultr/templates/issuers.yaml
+++ b/deploy/cert-manager-webhook-vultr/templates/issuers.yaml
@@ -1,0 +1,39 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: vultr-letsencrypt-staging
+spec:
+  acme:
+    email: {{ .Values.certManager.email }}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: vultr-letsencrypt-staging
+    solvers:
+      - dns01:
+          webhook:
+            groupName: acme.vultr.com
+            solverName: vultr
+            config:
+              apiKeySecretRef:
+                key: apiKey
+                name: {{ .Values.secretName }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: vultr-letsencrypt-prod
+spec:
+  acme:
+    email: {{ .Values.certManager.email }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: vultr-letsencrypt-prod
+    solvers:
+      - dns01:
+          webhook:
+            groupName: acme.vultr.com
+            solverName: vultr
+            config:
+              apiKeySecretRef:
+                key: apiKey
+                name: {{ .Values.secretName }}

--- a/deploy/cert-manager-webhook-vultr/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-vultr/templates/rbac.yaml
@@ -126,3 +126,28 @@ subjects:
     kind: ServiceAccount
     name: {{ include "cert-manager-webhook-vultr.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cert-manager-webhook-vultr.fullname" . }}:secret-reader
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ .Values.secretName }}]
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-vultr.fullname" . }}:secret-reader
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-webhook-vultr.fullname" . }}:secret-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ .Values.certManager.serviceAccountName }}

--- a/deploy/cert-manager-webhook-vultr/values.yaml
+++ b/deploy/cert-manager-webhook-vultr/values.yaml
@@ -7,10 +7,12 @@
 # This group name should be **unique**, hence using your own company's domain
 # here is recommended.
 groupName: acme.vultr.com
+secretName: vultr-credentials
 
 certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager
+  email: changeme@email.com
 
 image:
   repository: vultr/cert-manager-webhook-vultr


### PR DESCRIPTION
## Description
This PR will move the secret-reader RBAC, and clusterissuers into the helm deployment so that it does not need to be created separately anymore. 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
